### PR TITLE
pr #7 improve user registration endpoint and schema updates

### DIFF
--- a/app/modules/user/repository.py
+++ b/app/modules/user/repository.py
@@ -4,20 +4,20 @@ from app.common.exceptions.app_exceptions import DuplicateEntryException
 from app.utils.security.password_context import PasswordContext
 
 from .models import User
-from .schemas import UserInsert
+from .schemas import UserCreate
 
 
 class UserRepository:
     def __init__(self, session: Session):
         self.session = session
 
-    def create(self, data: UserInsert) -> User:
+    def create(self, data: UserCreate) -> User:
         data.password = PasswordContext.hash_password(data.password)
+
+        if self.get_by_email(data.email) is not None:
+            raise DuplicateEntryException("email", data.email)
+
         user = User(**data.model_dump())
-
-        if self.get_by_email(user.email) is not None:
-            raise DuplicateEntryException("email", user.email)
-
         self.session.add(user)
         self.session.commit()
         self.session.refresh(user)

--- a/app/modules/user/routers.py
+++ b/app/modules/user/routers.py
@@ -8,7 +8,7 @@ from app.common.http_response.reponses import ResponseError
 from app.db.session import get_session
 
 from .repository import UserRepository
-from .schemas import UserInsert, UserView
+from .schemas import UserCreate, UserRead
 
 router = APIRouter(
     prefix="/users",
@@ -18,14 +18,14 @@ router = APIRouter(
 
 
 @router.post(
-    "/register",
-    response_model=UserView,
+    "/",
+    response_model=UserRead,
     status_code=status.HTTP_201_CREATED,
     responses={
         **ResponseError.HTTP_409_CONFLICT("User already exists"),
     },
 )
-async def register_user(user_register_data: UserInsert, session: Annotated[Session, Depends(get_session)]) -> UserView:
+async def register_user(user_register_data: UserCreate, session: Annotated[Session, Depends(get_session)]) -> UserRead:
         user = UserRepository(session).create(user_register_data)
         return user
    

--- a/app/modules/user/schemas.py
+++ b/app/modules/user/schemas.py
@@ -1,35 +1,67 @@
-from typing import Optional
+from datetime import datetime
 
 from pydantic import BaseModel, EmailStr, Field
 
 from .models import UserRole, UserStatus
 
 
-class UserInsert(BaseModel):
-    first_name: str = Field(min_length=1, max_length=255, description="User's first name")
-    last_name: str = Field(min_length=1, max_length=255, description="User's last name")
-    email: EmailStr = Field(description="User's email address")
-    password: str = Field(min_length=8, max_length=255, description="User's hashed password")
-    picture: Optional[str] = Field(default=None, description="Path to user's profile picture")
-    role: UserRole = Field(default=UserRole.USER, description="User role (0=user, 1=admin)")
-    status: UserStatus = Field(default=UserStatus.DEACTIVE, description="User status")
-    phone: Optional[str] = Field(default=None, pattern=r"^\+[0-9]{10,15}$", description="User's phone number")
-    address: Optional[str] = Field(default=None, description="User's address")
+class UserBase(BaseModel):
+    first_name: str | None = Field(max_length=255, description="User's first name", examples=["John"])
+    last_name: str | None = Field(max_length=255, description="User's last name", examples=["Doe"])
+    email: EmailStr = Field(..., description="User's unique email address", examples=["john.doe@example.com"])
+    picture: str | None = Field(
+        description="URL or path to user's profile picture",
+        examples=["https://example.com/photos/123.jpg"],
+    )
+    role: UserRole = Field(default=UserRole.USER, description="Role of the user, e.g. 0, 1 and etc", examples=[0])
+    status: UserStatus = Field(
+        default=UserStatus.DEACTIVE,
+        description="Current status of the user account",
+        examples=[0],
+    )
+    phone: str | None = Field(description="User's phone number", examples=["+1-555-555-0123"])
+    address: str | None = Field(description="User's physical address", examples=["123 Main St, City, Country"])
 
     class Config:
         use_enum_values = True
 
 
-class UserView(BaseModel):
-    id: int = Field(gt=0, description="User ID")
-    first_name: str = Field(min_length=1, max_length=255, description="User's first name")
-    last_name: str = Field(min_length=1, max_length=255, description="User's last name")
-    email: EmailStr
-    picture: Optional[str] = Field(default=None, description="Path to user's profile picture")
-    role: UserRole = Field(default=UserRole.USER, description="User role (0=user, 1=admin)")
-    status: UserStatus = Field(default=UserStatus.DEACTIVE, description="User status")
-    phone: Optional[str] = Field(pattern=r"^\+[0-9]{10,15}$", description="User's phone number")
-    address: Optional[str] = Field(default=None, description="User's address")
+class UserCreate(UserBase):
+    password: str = Field(
+        ...,
+        min_length=8,
+        description="User's account password (min 8 characters)",
+        examples=["StrongP@ss123"],
+    )
+
+
+class UserUpdate(BaseModel):
+    first_name: str | None = Field(description="Updated first name", examples=["Jane"])
+    last_name: str | None = Field(description="Updated last name", examples=["Smith"])
+    email: EmailStr | None = Field(description="Updated email", examples=["jane.smith@example.com"])
+    password: str | None = Field(min_length=8, description="Updated password", examples=["NewP@ss456"])
+    picture: str | None = Field(
+        description="Updated profile picture URL",
+        examples=["https://example.com/photos/456.jpg"],
+    )
+    role: UserRole | None = Field(description="Updated user role", examples=[1])
+    status: UserStatus | None = Field(description="Updated user status", examples=[1])
+    phone: str | None = Field(description="Updated phone number", examples=["+1-555-555-0456"])
+    address: str | None = Field(description="Updated address", examples=["456 Oak Ave, City, Country"])
+
+
+class UserRead(UserBase):
+    id: int = Field(..., description="Unique ID of the user", examples=[1])
+    date_created: datetime = Field(
+        ...,
+        description="Timestamp when the user was created",
+        examples=["2023-01-01T00:00:00"],
+    )
+    date_modified: datetime = Field(
+        ...,
+        description="Timestamp when the user was last updated",
+        examples=["2023-01-01T12:30:00"],
+    )
 
     class Config:
-        use_enum_values = True
+        from_attributes = True


### PR DESCRIPTION
This commit introduces the user registration endpoint and updates the user schemas to improve clarity and flexibility.

- Renames `UserInsert` to `UserCreate` and `UserView` to `UserRead` for better semantic meaning.
- Introduces `UserBase` and `UserUpdate` schemas for code reuse and clearer update operations.
- Adds example values to schema fields for better documentation and client-side generation.
- Modifies the `/users` POST route to use the new schemas.
- Improves phone number validation in `UserBase`.
- Removes unnecessary phone pattern validation from `UserView`.
- Adds `date_created` and `date_modified` fields to `UserRead`.